### PR TITLE
parse duration

### DIFF
--- a/access-restrictor/lua/ngx/setRate.lua
+++ b/access-restrictor/lua/ngx/setRate.lua
@@ -1,13 +1,6 @@
-function parse_duration(input)
-  -- XXX: make parts optional
-  days, hours, minutes, seconds = string.match(input, "^P(%d*)DT(%d*)H(%d*)M(%d*)S$")
-  assert(days or hours or minutes or seconds)
-
-  return tonumber(days) or 0,tonumber(hours) or 0, tonumber(minutes) or 0, tonumber(seconds) or 0
-end
-
 if ngx.var.request_method == "PUT" then
-  days, hours, minutes, seconds = parse_duration(ngx.var.rate)
+  local duration = require("duration")
+  days, hours, minutes, seconds = duration:parse(ngx.var.rate)
 
   local rate = (((days * 60 + hours) * 60) + minutes) * 60 + seconds
   if (rate == nil) or (rate <= 0) then

--- a/access-restrictor/lua/spec/duration_spec.lua
+++ b/access-restrictor/lua/spec/duration_spec.lua
@@ -1,0 +1,26 @@
+describe("Duration", function()
+    local Duration = {}
+    before_each(function ()
+        Duration = require("../src/duration")
+    end)
+
+    it("should parse all", function()
+        days, hours, minutes, seconds = Duration:parse("P1DT2H3M4S");
+        assert.are.same(1, days);
+        assert.are.same(2, hours);
+        assert.are.same(3, minutes);
+        assert.are.same(4, seconds);
+    end)
+
+    it("should parse only one", function()
+        days, hours, minutes, seconds = Duration:parse("P1H");
+        assert.are.same(0, days);
+        assert.are.same(1, hours);
+        assert.are.same(0, minutes);
+        assert.are.same(0, seconds);
+    end)
+
+    it("should fail if wrong format", function()
+        assert.has_error(function() Duration:parse("P1S1H") end, "wrong duration format")
+    end)
+end)

--- a/access-restrictor/lua/src/duration.lua
+++ b/access-restrictor/lua/src/duration.lua
@@ -1,0 +1,12 @@
+local Duration = {};
+
+function Duration:parse(duration)
+    assert(string.match(duration, "^P(%d*)D?T?(%d*)H?(%d*)M?(%d*)S?$"), "wrong duration format");
+    days = tonumber(string.match(duration, "^P(%d*)D")) or 0;
+    hours = tonumber(string.match(duration, "(%d*)H")) or 0;
+    minutes = tonumber(string.match(duration, "(%d*)M")) or 0;
+    seconds = tonumber(string.match(duration, "(%d*)S$")) or 0;
+    return days, hours, minutes, seconds;
+end
+
+return Duration;


### PR DESCRIPTION
"^P(%d*)D?T?(%d*)H?(%d*)M?(%d*)S?$"
Hätte gerne DT in eine Gruppe gepackt, aber das scheint in Lua nicht so ohne weiteres zu klappen:

> Limitations of Lua patterns
> 
> Especially if you're used to other languages with regular expressions, you might expect to be able to do stuff like this:
> 
> '(foo)+' -- match the string "foo" repeated one or more times
> '(foo|bar)' -- match either the string "foo" or the string "bar"
> Unfortunately Lua patterns do not support this, only single characters can be repeated or chosen between, not sub-patterns or strings. The solution is to either use multiple patterns and write some custom logic, use a regular expression library like lrexlib or Lua PCRE, or use LPeg [3]. LPeg is a powerful text parsing library for Lua based on Parsing Expression Grammar [4]. It offers functions to create and combine patterns in Lua code, and also a language somewhat like Lua patterns or regular expressions to conveniently create small parsers.
(http://lua-users.org/wiki/PatternsTutorial)